### PR TITLE
Update image id

### DIFF
--- a/ec2.yml
+++ b/ec2.yml
@@ -6,7 +6,7 @@
     keypair: ansible
     instance_type: t2.micro
     security_group: sg-ba9a5ede
-    image: ami-f95ef58a
+    image: ami-5dd8b73a
     region: eu-west-1
     subnet: subnet-7a522c0d
     groupname: webservers


### PR DESCRIPTION
Hi, I find out that `ami-f95ef58a` does not exist anymore. 
`Ubuntu Server 14.04 LTS (HVM), SSD Volume Type`'s latest image id is `ami-5dd8b73a`.